### PR TITLE
Add main entry point for candecode and update Makefile for build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ OPENDBC_DBC_DIR 		:= $(OPENDBC_DIR)/opendbc/dbc
 OPENDBC_SOURCES 		:= $(shell find $(OPENDBC_GENERATOR_DIR) -name "*.py" -o \( -name "*.dbc" -not -name "*_generated.dbc" \) 2>/dev/null)
 OPENDBC_STAMP 			:= $(BIN_DIR)/.opendbc_stamp
 # candecode build target with dependency tracking
+CANDECODE_MAIN			:= ./cmd/candecode/main.go
 CANDECODE_SOURCES		:= $(shell find . -name "*.go" -not -path "$(OPENDBC_DIR)/*" 2>/dev/null) go.mod go.sum
 CANDECODE_BINARY		:= $(BIN_DIR)/candecode
 # buf build target with dependency tracking
@@ -69,7 +70,7 @@ $(CANDECODE_BINARY): $(CANDECODE_SOURCES) $(BUF_TARGETS)
 	@echo "Building candecode binary..."
 	@mkdir -p $(BIN_DIR)
 	@go mod tidy
-	@$(BUILD_ENV) go build $(BUILD_OPTS) -o $(CANDECODE_BINARY) ./cmd/main.go
+	@$(BUILD_ENV) go build $(BUILD_OPTS) -o $(CANDECODE_BINARY) $(CANDECODE_MAIN)
 	@echo "Binary built: $(CANDECODE_BINARY)"
 
 .PHONY: build/opendbc

--- a/cmd/candecode/main.go
+++ b/cmd/candecode/main.go
@@ -15,7 +15,6 @@ func main() {
 
 	c.AddCommands(
 		convert.NewCommand(),
-		// gen.NewCommand(),
 	)
 
 	if err := c.Run(); err != nil {


### PR DESCRIPTION
This pull request updates the build process for the `candecode` binary and refines its source organization. The main changes include specifying the main entrypoint for the `candecode` binary, updating the Makefile to use this new entrypoint, and removing a commented-out command from the main function.

Build process and source organization:

* Added a new `CANDECODE_MAIN` variable in the `Makefile` to explicitly specify the main entrypoint for the `candecode` binary as `./cmd/candecode/main.go`.
* Updated the build command in the `Makefile` to use the new `CANDECODE_MAIN` variable instead of the previous `./cmd/main.go` path.

Code cleanup:

* Removed a commented-out command (`gen.NewCommand()`) from the `main()` function in `cmd/candecode/main.go` for clarity.